### PR TITLE
sqm-scripts: syncronise changes made for Openwrt pull request

### DIFF
--- a/luci/luci-app-sqm/Makefile
+++ b/luci/luci-app-sqm/Makefile
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2010 OpenWrt.org
+# Copyright (C) 2014 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -17,7 +17,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/luci-app-sqm
   SECTION:=luci
   CATEGORY:=LuCI
-  TITLE:=SQM script LuCI interface
+  TITLE:=SQM Scripts - LuCI interface
   MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
   PKGARCH:=all
   DEPENDS:= lua luci-base +sqm-scripts

--- a/luci/luci-app-sqm/files/sqm-controller.lua
+++ b/luci/luci-app-sqm/files/sqm-controller.lua
@@ -21,6 +21,6 @@ function index()
 	
 	local page
 
-	page = entry({"admin", "network", "sqm"}, cbi("sqm"), _("SQM"))
+	page = entry({"admin", "network", "sqm"}, cbi("sqm"), _("SQM QoS"))
 	page.dependent = true
 end

--- a/net/sqm-scripts/Makefile
+++ b/net/sqm-scripts/Makefile
@@ -1,5 +1,5 @@
 # 
-# Copyright (C) 2006-2011 OpenWrt.org
+# Copyright (C) 2014 OpenWrt.org
 #
 # This is free software, licensed under the GNU General Public License v2.
 # See /LICENSE for more information.
@@ -18,9 +18,11 @@ include $(INCLUDE_DIR)/package.mk
 define Package/sqm-scripts
   SECTION:=net
   CATEGORY:=Base system
-  DEPENDS:=+tc +kmod-sched +ip +kmod-ifb iptables +iptables-mod-filter +iptables-mod-ipopt +iptables-mod-conntrack-extra
-  TITLE:=SQM Scripts
+  DEPENDS:=+tc +kmod-sched +kmod-ifb iptables +ip \
+	+iptables-mod-filter +iptables-mod-ipopt +iptables-mod-conntrack-extra
+  TITLE:=SQM Scripts (QoS)
   PKGARCH:=all
+  MAINTAINER:=Toke Høiland-Jørgensen <toke@toke.dk>
 endef
 
 define Package/sqm-scripts/description

--- a/net/sqm-scripts/files/usr/lib/sqm/simple_pppoe.qos.help
+++ b/net/sqm-scripts/files/usr/lib/sqm/simple_pppoe.qos.help
@@ -1,2 +1,2 @@
-BW-limited three-tier prioritisation scheme with fq_codel on each queue. Temporary version to impolement shaping
+BW-limited three-tier prioritisation scheme with fq_codel on each queue. Temporary version to implement shaping
 of pass through PPPOE encapsulated packets.


### PR DESCRIPTION
This commit includes the Makefile changes & small menu/typo fixes
done for the Openwrt pull request.

Additionally I moved the Luci app also to /net, as the Openwrt packages does not have a separate /luci dir. But I did not include that change in here.

For Openwrt I also changed the config defaults slightly:
eth1 interface, my own speeds, advanced options initially hidden

Signed-off-by: Hannu Nyman hannu.nyman@iki.fi
