### PR TITLE
fix var DEFAULTS from m (manual) to n (none)

### DIFF
--- a/devel/libasio/Makefile
+++ b/devel/libasio/Makefile
@@ -27,7 +27,7 @@ include $(INCLUDE_DIR)/package.mk
 define Package/libasio
   SECTION:=libs
   CATEGORY:=Libraries
-  DEFAULT:=m
+  DEFAULT:=n
   TITLE:=libasio
   URL:=http://think-async.com/
   DEPENDS:=+boost

--- a/net/resiprocate/Makefile
+++ b/net/resiprocate/Makefile
@@ -30,7 +30,7 @@ define Package/resiprocate/Default
   SECTION:=net
   CATEGORY:=Network
   SUBMENU:=Telephony
-  DEFAULT:=m
+  DEFAULT:=n
   TITLE:=reSIProcate
   URL:=http://www.resiprocate.org/
   DEPENDS:=+libopenssl +libdb47 +libcares +boost +libstdcpp


### PR DESCRIPTION
The two ackages "libasio" and "resiprocate" use var DEFAULTS=m (manual).
This leads to have them selected and build by default with all their
dependencies, which should not be the case by just including the feed
ceropackages-3.10.
Change the DEFAULT from "m" (manual) to "n" none.

Signed-off-by: Thomas Huehn <thomas@net.t-labs.tu-berlin.de>